### PR TITLE
Token Config

### DIFF
--- a/app/Config.hs
+++ b/app/Config.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Config where
+
+import qualified Data.Text as T
+import Debug.Trace
+import Dhall
+import System.Directory (XdgDirectory (XdgConfig), doesPathExist, getXdgDirectory)
+import System.Environment (lookupEnv)
+import System.FilePath
+
+opeDir :: FilePath
+opeDir = "ope"
+
+tokenFilePath :: FilePath
+tokenFilePath = "token.dhall"
+
+data Token = Token {githubToken :: Text}
+  deriving (Generic, Show)
+
+instance FromDhall Token
+
+-- | Read token from env var GITHUB_TOKEN
+envToken :: IO (Maybe T.Text)
+envToken = (fmap . fmap) T.pack $ lookupEnv "GITHUB_TOKEN"
+
+-- | Read token from ~/.config/ope/token.dhall
+fileToken :: IO (Maybe T.Text)
+fileToken = do
+  configFile <- (</> tokenFilePath) <$> getXdgDirectory XdgConfig opeDir
+  exists <- doesPathExist configFile
+  if exists
+    then return . githubToken <$> input auto (T.pack configFile)
+    else return Nothing

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,6 @@
 module Main where
 
+import Config
+
 main :: IO ()
 main = putStrLn "Ope!"

--- a/ope.cabal
+++ b/ope.cabal
@@ -51,7 +51,7 @@ executable ope
   main-is:             Main.hs
 
   -- Modules included in this executable, other than Main.
-  -- other-modules:
+  other-modules:       Config
 
   -- LANGUAGE extensions used by modules in this package.
   -- other-extensions:
@@ -59,7 +59,10 @@ executable ope
   -- Other library packages from which modules are imported.
   build-depends:       base ^>=4.13.0.0,
                        github ^>=0.26,
-                       text
+                       text,
+                       filepath,
+                       directory,
+                       dhall ^>=1.35
 
   -- Directories containing source files.
   hs-source-dirs:      app

--- a/ope.cabal
+++ b/ope.cabal
@@ -57,7 +57,9 @@ executable ope
   -- other-extensions:
 
   -- Other library packages from which modules are imported.
-  build-depends:       base ^>=4.13.0.0
+  build-depends:       base ^>=4.13.0.0,
+                       github ^>=0.26,
+                       text
 
   -- Directories containing source files.
   hs-source-dirs:      app

--- a/shell.nix
+++ b/shell.nix
@@ -11,5 +11,6 @@ in
       hlint
       ghcid
       niv
+      zlib
     ];
   }


### PR DESCRIPTION
Adds support for reading the token either from an env var or from a Dhall file in the `XDG_CONFIG/ope` directory